### PR TITLE
msm8996-common: Enable interaction boost

### DIFF
--- a/BoardConfigCommon.mk
+++ b/BoardConfigCommon.mk
@@ -166,6 +166,7 @@ TARGET_USES_MKE2FS := true
 # Power
 TARGET_HAS_NO_WIFI_STATS := true
 TARGET_TAP_TO_WAKE_NODE := "/sys/devices/virtual/touch/tp_dev/gesture_on"
+TARGET_USES_INTERACTION_BOOST := true
 
 # QCOM
 BOARD_USES_QCOM_HARDWARE := true


### PR DESCRIPTION
This enables power profiles in LineageOS and fixes issue #10.